### PR TITLE
Prevent blank fields from being written when specifying a layout.

### DIFF
--- a/NLog.MongoDB/MongoDBTarget.cs
+++ b/NLog.MongoDB/MongoDBTarget.cs
@@ -132,7 +132,9 @@ namespace NLog.MongoDB
 			{
 				if (field.Layout != null)
 				{
-					doc[field.Name] = field.Layout.Render(logEvent);
+					var renderedField = field.Layout.Render(logEvent);
+					if (!string.IsNullOrWhiteSpace(renderedField))
+						doc[field.Name] = renderedField;
 					continue;
 				}
 


### PR DESCRIPTION
Hello, this is my first contribution to a project on GitHub, I hope I'm doing this correctly!

When a field is specified in the NLog.config, it is not written to the database unless it has a value. However, if a field has a custom layout, it is always written to the database, adding unnecessary clutter. For example, I'd like to add a field for the exception type, but I'm not always necessarily logging an exception.
