### PR TITLE
Support for nested documents within custom formatting

### DIFF
--- a/NLog.MongoDB.Tests/IntegrationTests/IntegrationTests.cs
+++ b/NLog.MongoDB.Tests/IntegrationTests/IntegrationTests.cs
@@ -212,6 +212,45 @@ namespace NLog.MongoDB.Tests
 			db.DropCollection(loggerName);
 			server.Disconnect();
 		}
+
+        [TestMethod]
+        public void Test_NestedDocuments()
+        {
+            var connectionString = ConfigurationManager.ConnectionStrings["MongoDB"].ConnectionString;
+            var server = MongoServer.Create(connectionString);
+            var connectionStringBuilder = new MongoUrlBuilder(connectionString);
+            var dbName = connectionStringBuilder.DatabaseName;
+            var loggerName = "nestedDocuments";
+
+            var db = server.GetDatabase(dbName);
+            var collection = db.GetCollection(loggerName);
+
+            // Clear out test collection
+            collection.RemoveAll();
+
+            var logger = LogManager.GetLogger(loggerName);
+
+            logger.LogException(
+                LogLevel.Error,
+                "Test Log Message",
+                new Exception("Test Exception", new Exception("Inner Exception")));
+
+            Thread.Sleep(2000);
+
+            collection.FindAll().Count().Should().Be(1);
+
+            var logEntry = collection.FindAll().First();
+
+            Assert.IsTrue(logEntry.Contains("_id"));
+
+            logEntry["level"].Should().Be(LogLevel.Error.ToString());
+            logEntry["nestedDocument"].AsBsonDocument["message"].Should().Be("Test Log Message");
+            logEntry["nestedDocument"].AsBsonDocument["nestedException"].AsBsonDocument["exception"].AsBsonDocument["message"].Should().Be("Test Exception");
+
+            // Clean-up
+            db.DropCollection(loggerName);
+            server.Disconnect();
+        }
 		
 		[TestMethod]
 		public void Test_ConnectionName()

--- a/NLog.MongoDB.Tests/NLog.MongoDB.Tests.csproj
+++ b/NLog.MongoDB.Tests/NLog.MongoDB.Tests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="IntegrationTests\IntegrationTests.cs" />
     <Compile Include="UnitTests\TestMongoTarget.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UnitTests\TestMongoTargetDocument.cs" />
     <Compile Include="UnitTests\TestMongoTargetField.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NLog.MongoDB.Tests/NLog.config
+++ b/NLog.MongoDB.Tests/NLog.config
@@ -44,6 +44,17 @@
       <field name="timestamp" />
     </target>
 
+    <target type="MongoDB" name="Mongo-NestedDocuments" connectionName="MongoDB">
+      <field name="level" />
+      <document name="nestedDocument">
+        <field name="timestamp" />
+        <field name="message" />
+        <document name="nestedException">
+          <field name="exception" />
+        </document>
+      </document>
+    </target>
+
   </targets>
   <rules>
     <logger name="testMongo" minLevel="Info" appendTo="Mongo"/>
@@ -53,5 +64,6 @@
     <logger name="testDynamicTypedFields" minLevel="Info" appendTo="Mongo-ConnectionName-TypedFields"/>
     <logger name="cappedWithId" minLevel="Info" appendTo="Mongo-CappedWithId"/>
     <logger name="cappedWithoutId" minLevel="Info" appendTo="Mongo-CappedWithoutId"/>
+    <logger name="nestedDocuments" minLevel="Info" appendTo="Mongo-NestedDocuments"/>
   </rules>
 </nlog>

--- a/NLog.MongoDB.Tests/UnitTests/TestMongoTargetDocument.cs
+++ b/NLog.MongoDB.Tests/UnitTests/TestMongoTargetDocument.cs
@@ -1,0 +1,26 @@
+﻿using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NLog.Layouts;
+
+namespace NLog.MongoDB.Tests
+{
+    [TestClass]
+    public class TestMongoTargetDocument
+    {
+        [TestMethod]
+        public void TestConstructor()
+        {
+            const string name = "SomeName!";
+
+            var doc = new MongoDBTargetDocument();
+            doc.Name = name;
+
+            doc.Name
+                .Should().Be(name);
+            doc.Fields.Count
+                .Should().Be(0);
+            doc.Documents.Count
+                .Should().Be(0);
+        }
+    }
+}

--- a/NLog.MongoDB.sln
+++ b/NLog.MongoDB.sln
@@ -7,8 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NLog.MongoDB.Tests", "NLog.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{4280133F-10A6-40AC-AC17-8769A243D07E}"
 	ProjectSection(SolutionItems) = preProject
-		C:\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.Config = C:\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.Config
-		C:\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.exe = C:\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.exe
+		..\..\..\..\..\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.Config = ..\..\..\..\..\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.Config
+		..\..\..\..\..\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.exe = ..\..\..\..\..\Projects\IPC.Web\Framework\MVC\_Lib\Tools\NuGet.exe
 		.nuget\NuGet.settings.targets = .nuget\NuGet.settings.targets
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection

--- a/NLog.MongoDB/MongoDBTargetDocument.cs
+++ b/NLog.MongoDB/MongoDBTargetDocument.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+using NLog.Config;
+using NLog.Layouts;
+
+namespace NLog.MongoDB
+{
+    [NLogConfigurationItem]
+    public sealed class MongoDBTargetDocument
+    {
+        public MongoDBTargetDocument()
+        {
+            Fields = new List<MongoDBTargetField>();
+            Documents = new List<MongoDBTargetDocument>();
+        }
+
+        [RequiredParameter]
+        public string Name { get; set; }
+
+        [ArrayParameter(typeof(MongoDBTargetField), "field")]
+        public IList<MongoDBTargetField> Fields { get; private set; }
+
+        [ArrayParameter(typeof(MongoDBTargetDocument), "document")]
+        public IList<MongoDBTargetDocument> Documents { get; private set; }
+    }
+}

--- a/NLog.MongoDB/NLog.MongoDB.csproj
+++ b/NLog.MongoDB/NLog.MongoDB.csproj
@@ -61,6 +61,7 @@
     <Compile Include="IRepositoryProvider.cs" />
     <Compile Include="LogEventInfoExtensions.cs" />
     <Compile Include="MongoDBTarget.cs" />
+    <Compile Include="MongoDBTargetDocument.cs" />
     <Compile Include="MongoDBTargetField.cs" />
     <Compile Include="MongoRepository.cs" />
     <Compile Include="MongoServerProvider.cs" />


### PR DESCRIPTION
Hello,

Just took a crack at a pretty major enhancement here... Being able to specify fields is great, but it would be even better if we could specify the document structure in the NLog.config file. For example, I could define my own structure for an Exception document to leverage custom field formatting, without giving up the Document object that it's stored in in the default case. 

Let me know if there's anything I could have done better, or if you had another thing in mind for how this might be implemented. Thanks!
